### PR TITLE
Fix header to revert to old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-left">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <div class="header-right">
                     <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light theme">
                         <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -69,7 +69,6 @@ body {
 /* Header */
 header {
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     padding: 1rem 2rem;
     flex-shrink: 0;
     transition: background-color 0.3s ease, border-color 0.3s ease;
@@ -77,35 +76,15 @@ header {
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-.header-left {
-    flex: 1;
-}
-
 .header-right {
     display: flex;
     align-items: center;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
 }
 
 /* Theme Toggle Button */


### PR DESCRIPTION
Fixes #4

## Changes
- Removed 'Course Materials Assistant' header text
- Removed subtitle about asking questions
- Removed horizontal divider (border-bottom)
- Kept theme toggle functionality intact
- Cleaned up unused CSS rules

Generated with [Claude Code](https://claude.ai/code)